### PR TITLE
feat: jetzt unterschreiben

### DIFF
--- a/src/components/helpers/translations.utils.ts
+++ b/src/components/helpers/translations.utils.ts
@@ -15,16 +15,16 @@ const SUPPORTED_LANGUAGES: string[] = ['de', 'fr', 'it', 'en'];
 
 const TRANSLATIONS: Translations = {
   de: {
-    sign: 'unterschreiben',
+    sign: 'Jetzt unterschreiben',
   },
   fr: {
-    sign: 'signer',
+    sign: 'Signer',
   },
   it: {
-    sign: 'firmare',
+    sign: 'Firmare',
   },
   en: {
-    sign: 'sign',
+    sign: 'Sign now',
   },
 };
 


### PR DESCRIPTION
According manu's design the text should be "Jetzt unterschreiben"

Notabene: not translated in french, "signer maintenant" sounds silly.